### PR TITLE
fix: point Vercel build to web workspace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Shared environment variables
+DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
+NEXT_PUBLIC_API_BASE=http://localhost:4000
+SESSION_SECRET=devsecret

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# codex-tinder3
+# FlameMate Web (Skeleton)
+
+This repository contains a simplified skeleton for a learning Tinder-like application built with Next.js, Express, Prisma, and PostgreSQL.
+
+## Development
+
+```bash
+docker compose up --build
+```
+
+The stack includes:
+- `web` Next.js frontend at port 3000.
+- `api` Express backend at port 4000.
+- `db` PostgreSQL at port 5432.
+
+Environment variables can be configured via `.env` files. See `.env.example` for defaults.
+
+## Vercel
+
+The repository includes a root `vercel.json` that directs Vercel to build the Next.js
+application located in the `web` workspace:
+
+```json
+{
+  "builds": [{ "src": "web/package.json", "use": "@vercel/next" }],
+  "routes": [{ "src": "/(.*)", "dest": "web/$1" }]
+}
+```
+
+During deployment Vercel installs all workspace dependencies with
+`npm install --workspaces --include-workspace-root` and then runs the Next.js build:
+
+```bash
+npm run build --workspace web
+```
+
+All application code lives under the `web` directory so no root `next.config.js` is
+required.
+

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --quiet
+COPY . .
+CMD ["npm","run","start"]

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "flamemate-api",
+  "private": true,
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "ts-node src/index.ts",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "cors": "^2.8.5",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.get('/', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+const port = 4000;
+app.listen(port, () => {
+  console.log(`API listening on port ${port}`);
+});

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:16
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - '5432:5432'
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+  api:
+    build: ./api
+    command: npm run dev
+    volumes:
+      - ./api:/app
+      - ./packages:/packages
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/postgres
+      SESSION_SECRET: devsecret
+    depends_on:
+      - db
+    ports:
+      - '4000:4000'
+
+  web:
+    build: ./web
+    command: npm run dev
+    volumes:
+      - ./web:/app
+      - ./packages:/packages
+    environment:
+      NEXT_PUBLIC_API_BASE: http://api:4000
+      DATABASE_URL: postgres://postgres:postgres@db:5432/postgres
+    depends_on:
+      - api
+    ports:
+      - '3000:3000'
+
+volumes:
+  db-data:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "flamemate-web",
+  "private": true,
+  "workspaces": ["packages/*", "api", "web"],
+  "scripts": {
+    "db:generate": "prisma generate --schema packages/db/prisma/schema.prisma",
+    "vercel-build": "npm run build --workspace web"
+  },
+  "devDependencies": {
+    "prisma": "^5.9.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "core",
+  "private": true,
+  "main": "src/index.ts",
+  "dependencies": {
+    "zod": "^3.22.4",
+    "@prisma/client": "^5.9.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,3 @@
+export function placeholder() {
+  return 'core module';
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "db",
+  "private": true,
+  "main": "src/client.ts",
+  "scripts": {
+    "generate": "prisma generate --schema prisma/schema.prisma",
+    "migrate": "prisma migrate dev --schema prisma/schema.prisma",
+    "seed": "ts-node seed.ts"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.9.1"
+  },
+  "devDependencies": {
+    "prisma": "^5.9.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1,0 +1,70 @@
+generator client {
+  provider        = "prisma-client-js"
+  output          = "../src/generated"
+  binaryTargets   = ["debian-openssl-3.0.x"]
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  password  String
+  profile   Profile?
+  counter   Counter?
+  createdAt DateTime @default(now())
+}
+
+model Profile {
+  id        Int      @id @default(autoincrement())
+  userId    Int      @unique
+  user      User     @relation(fields: [userId], references: [id])
+  name      String
+  age       Int
+  bio       String?
+  photos    Photo[]
+  createdAt DateTime @default(now())
+}
+
+model Photo {
+  id        Int      @id @default(autoincrement())
+  profileId Int
+  url       String
+  profile   Profile @relation(fields: [profileId], references: [id])
+}
+
+model Swipe {
+  id        Int      @id @default(autoincrement())
+  fromId    Int
+  toId      Int
+  type      String
+  createdAt DateTime @default(now())
+}
+
+model Match {
+  id        Int      @id @default(autoincrement())
+  userAId   Int
+  userBId   Int
+  createdAt DateTime @default(now())
+  messages  Message[]
+}
+
+model Message {
+  id        Int      @id @default(autoincrement())
+  matchId   Int
+  senderId  Int
+  content   String
+  createdAt DateTime @default(now())
+  match     Match    @relation(fields: [matchId], references: [id])
+}
+
+model Counter {
+  id            Int    @id @default(autoincrement())
+  userId        Int    @unique
+  user          User   @relation(fields: [userId], references: [id])
+  superLikes    Int    @default(0)
+  boosts        Int    @default(0)
+}

--- a/packages/db/seed.ts
+++ b/packages/db/seed.ts
@@ -1,0 +1,30 @@
+import { prisma } from './src/client';
+
+async function main() {
+  const user = await prisma.user.create({
+    data: {
+      email: 'demo@example.com',
+      password: 'password',
+      profile: {
+        create: {
+          name: 'Demo User',
+          age: 25,
+          bio: 'This is a demo profile',
+          photos: {
+            create: [{ url: '/placeholder.jpg' }],
+          },
+        },
+      },
+      counter: {
+        create: { superLikes: 5, boosts: 1 },
+      },
+    },
+    include: { profile: { include: { photos: true } } },
+  });
+  console.log('Seeded user', user.email);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,0 +1,7 @@
+import { PrismaClient } from './generated';
+
+const globalForPrisma = global as unknown as { prisma?: PrismaClient };
+
+export const prisma = globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["src/**/*.ts", "seed.ts"],
+  "exclude": ["node_modules"]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "builds": [
+    { "src": "web/package.json", "use": "@vercel/next" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "web/$1" }
+  ],
+  "installCommand": "npm install --workspaces --include-workspace-root",
+  "buildCommand": "npm run build --workspace web"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,0 @@
-{
-  "builds": [
-    { "src": "web/package.json", "use": "@vercel/next" }
-  ],
-  "routes": [
-    { "src": "/(.*)", "dest": "web/$1" }
-  ],
-  "installCommand": "npm install --workspaces --include-workspace-root",
-}

--- a/vercel.json
+++ b/vercel.json
@@ -6,5 +6,4 @@
     { "src": "/(.*)", "dest": "web/$1" }
   ],
   "installCommand": "npm install --workspaces --include-workspace-root",
-  "buildCommand": "npm run build --workspace web"
 }

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --quiet
+COPY . .
+CMD ["npm","run","start"]

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-100 text-gray-900;
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css';
+import React from 'react';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <main className="p-4">FlameMate Web skeleton</main>;
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// See https://nextjs.org/docs/basic-features/typescript for more information.

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+module.exports = nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "flamemate-web-app",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- direct Vercel to build the Next.js app in the `web` workspace via explicit builder config
- simplify root package by removing Next.js dependency and stub config
- document new Vercel setup in the README

## Testing
- `npm run db:generate` *(fails: prisma: not found)*
- `npm run build --workspace web` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2a79b148832fb31ee8bb81fc8a0e